### PR TITLE
Accept a custom base uri for the go binaries

### DIFF
--- a/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
+++ b/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
@@ -23,6 +23,7 @@ import com.github.blindpirate.gogradle.util.StringUtils;
 import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Singleton;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,9 @@ public class GolangPluginSetting {
     // if true, the plugin will make its best effort to bypass the GFW
     // designed for Chinese developer
     private boolean fuckGfw;
+
+    // A user defined source for go binaries
+    private URI goBinaryDownloadRootUri;
 
     public String getGoRoot() {
         return goRoot;
@@ -142,6 +146,18 @@ public class GolangPluginSetting {
 
     public void setFuckGfw(boolean fuckGfw) {
         this.fuckGfw = fuckGfw;
+    }
+
+    public URI getGoBinaryDownloadBaseUri() {
+        return goBinaryDownloadRootUri;
+    }
+
+    public void setGoBinaryDownloadBaseUri(String goBinaryDownloadBaseUri) {
+        setGoBinaryDownloadBaseUri(goBinaryDownloadBaseUri == null ? null : URI.create(goBinaryDownloadBaseUri));
+    }
+
+    public void setGoBinaryDownloadBaseUri(URI goBinaryDownloadBaseUrl) {
+        this.goBinaryDownloadRootUri = goBinaryDownloadBaseUrl;
     }
 
     public void globalCacheFor(int count, String timeUnit) {

--- a/src/main/java/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManager.java
+++ b/src/main/java/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManager.java
@@ -19,7 +19,12 @@ package com.github.blindpirate.gogradle.crossplatform;
 
 import com.github.blindpirate.gogradle.GolangPluginSetting;
 import com.github.blindpirate.gogradle.core.cache.GlobalCacheManager;
-import com.github.blindpirate.gogradle.util.*;
+import com.github.blindpirate.gogradle.util.Assert;
+import com.github.blindpirate.gogradle.util.CompressUtils;
+import com.github.blindpirate.gogradle.util.HttpUtils;
+import com.github.blindpirate.gogradle.util.IOUtils;
+import com.github.blindpirate.gogradle.util.ProcessUtils;
+import com.github.blindpirate.gogradle.util.StringUtils;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.filefilter.TrueFileFilter;

--- a/src/main/java/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManager.java
+++ b/src/main/java/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManager.java
@@ -19,12 +19,7 @@ package com.github.blindpirate.gogradle.crossplatform;
 
 import com.github.blindpirate.gogradle.GolangPluginSetting;
 import com.github.blindpirate.gogradle.core.cache.GlobalCacheManager;
-import com.github.blindpirate.gogradle.util.Assert;
-import com.github.blindpirate.gogradle.util.CompressUtils;
-import com.github.blindpirate.gogradle.util.HttpUtils;
-import com.github.blindpirate.gogradle.util.IOUtils;
-import com.github.blindpirate.gogradle.util.ProcessUtils;
-import com.github.blindpirate.gogradle.util.StringUtils;
+import com.github.blindpirate.gogradle.util.*;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.filefilter.TrueFileFilter;
@@ -252,8 +247,15 @@ public class DefaultGoBinaryManager implements GoBinaryManager {
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private Path downloadArchive(String version) {
-        String baseUrl = urls.get(setting.isFuckGfw());
-        String url = injectVariables(baseUrl, version);
+        String url;
+        if (setting.getGoBinaryDownloadBaseUri() == null) {
+            String baseUrl = urls.get(setting.isFuckGfw());
+            url = injectVariables(baseUrl, version);
+        } else {
+            url = setting.getGoBinaryDownloadBaseUri().resolve(
+                    injectVariables("go${version}.${os}-${arch}${extension}", version)
+            ).toASCIIString();
+        }
         String archiveFileName = injectVariables(FILENAME, version);
         Path goBinaryCachePath = globalCacheManager.getGlobalGoBinCache(archiveFileName);
         forceMkdir(goBinaryCachePath.getParent().toFile());

--- a/src/test/groovy/com/github/blindpirate/gogradle/GolangPluginSettingTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/GolangPluginSettingTest.groovy
@@ -108,6 +108,18 @@ class GolangPluginSettingTest {
     }
 
     @Test
+    void 'setting go binary download base uri to a String should succeed'() {
+        setting.goBinaryDownloadBaseUri = 'http://example.com/'
+        assert setting.goBinaryDownloadBaseUri == URI.create('http://example.com/')
+    }
+
+    @Test
+    void 'setting go binary download base uri to a URI should succeed'() {
+        setting.goBinaryDownloadBaseUri = URI.create('http://example.com/')
+        assert setting.goBinaryDownloadBaseUri == URI.create('http://example.com/')
+    }
+
+    @Test
     void 'setting goroot should succeed'() {
         setting.goRoot = 'goroot'
         assert setting.goRoot == 'goroot'

--- a/src/test/groovy/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManagerTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManagerTest.groovy
@@ -214,6 +214,18 @@ class DefaultGoBinaryManagerTest extends MockEnvironmentVariableSupport {
         verify(httpUtils).download(anyString(), any(Path))
     }
 
+    @Test
+    void 'go binary with specified version should be downloaded when a modified go binary base url has been set'() {
+        // given
+        when(setting.getGoVersion()).thenReturn('1.7.4')
+        when(setting.getgoBinaryDownloadBaseUri()).thenReturn(URI.create('http://example.com/'))
+        // then
+        assert manager.getBinaryPath() == resource.toPath().resolve("1.7.4/go/bin/go${Os.getHostOs().exeExtension()}")
+        assert manager.getGoVersion() == '1.7.4'
+        assert manager.getGoroot() == resource.toPath().resolve('1.7.4/go')
+        verify(httpUtils).download("http://example.com/go1.7.4.${Os.getHostOs().toString()}-${Arch.getHostArch().toString()}${Os.getHostOs().archiveExtension()}", any(Path))
+    }
+
     @Test(expected = UncheckedIOException)
     void 'exception should be thrown when specified version is invalid'() {
         // given

--- a/src/test/groovy/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManagerTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManagerTest.groovy
@@ -218,12 +218,12 @@ class DefaultGoBinaryManagerTest extends MockEnvironmentVariableSupport {
     void 'go binary with specified version should be downloaded when a modified go binary base url has been set'() {
         // given
         when(setting.getGoVersion()).thenReturn('1.7.4')
-        when(setting.getgoBinaryDownloadBaseUri()).thenReturn(URI.create('http://example.com/'))
+        when(setting.getGoBinaryDownloadBaseUri()).thenReturn(URI.create('http://example.com/'))
         // then
         assert manager.getBinaryPath() == resource.toPath().resolve("1.7.4/go/bin/go${Os.getHostOs().exeExtension()}")
         assert manager.getGoVersion() == '1.7.4'
         assert manager.getGoroot() == resource.toPath().resolve('1.7.4/go')
-        verify(httpUtils).download("http://example.com/go1.7.4.${Os.getHostOs().toString()}-${Arch.getHostArch().toString()}${Os.getHostOs().archiveExtension()}", any(Path))
+        verify(httpUtils).download(eq("http://example.com/go1.7.4.${Os.getHostOs().toString()}-${Arch.getHostArch().toString()}${Os.getHostOs().archiveExtension()}".toString()), any(Path))
     }
 
     @Test(expected = UncheckedIOException)


### PR DESCRIPTION
In my experience, many organisations have restrictions on downloading binaries from the internet, particularly from build servers.  Instead, they often require binaries to be downloaded from an internal repository.

This PR adds a property to the plugin that allows you to specify where you'd like the go binaries downloaded from.

Note, I was unable to get all the tests to run - `gradlew check` produces a lot of failures like the below when I run it (I assume I've missed something):
```
org.mockito.exceptions.base.MockitoException: 
Mockito cannot mock this class: class com.github.blindpirate.gogradle.GolangPluginSetting.

Mockito can only mock non-private & non-final classes.
If you're not sure why you're getting this error, please report to the mailing list.


Java               : 1.8
JVM vendor name    : Oracle Corporation
JVM vendor version : 25.11-b03
JVM name           : Java HotSpot(TM) 64-Bit Server VM
JVM version        : 1.8.0_11-b12
JVM info           : mixed mode
OS name            : Linux
OS version         : 3.19.0-32-generic


Underlying exception : java.lang.IllegalArgumentException: java.lang.ClassCastException@210ea9c6
	at com.github.blindpirate.gogradle.GogradleRunner.createTest(GogradleRunner.groovy:63)
...

```