### PR TITLE
Deterministic order of locked dependencies

### DIFF
--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/lock/DefaultLockedDependencyManager.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/lock/DefaultLockedDependencyManager.java
@@ -17,6 +17,7 @@
 
 package com.github.blindpirate.gogradle.core.dependency.lock;
 
+import com.github.blindpirate.gogradle.core.dependency.GolangDependency;
 import com.github.blindpirate.gogradle.core.dependency.ResolvedDependency;
 import com.github.blindpirate.gogradle.core.dependency.produce.ExternalDependencyFactory;
 import com.github.blindpirate.gogradle.util.DataExchange;
@@ -27,6 +28,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -62,6 +64,7 @@ public class DefaultLockedDependencyManager extends ExternalDependencyFactory im
 
     private List<Map<String, Object>> toNotations(Collection<? extends ResolvedDependency> flatDependencies) {
         List<Map<String, Object>> ret = flatDependencies.stream()
+                .sorted(Comparator.comparing(GolangDependency::getName)) // to have a deterministic order
                 .map(ResolvedDependency::toLockedNotation)
                 .collect(Collectors.toList());
         ret.forEach(this::deactivateTransitive);

--- a/src/test/groovy/com/github/blindpirate/gogradle/core/dependency/lock/DefaultLockedDependencyManagerTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/core/dependency/lock/DefaultLockedDependencyManagerTest.groovy
@@ -82,18 +82,18 @@ dependencies:
     @Before
     void setUp() {
         ReflectionUtils.setField(manager, 'project', project)
-        when(dependency1.getName()).thenReturn('a')
-        when(dependency2.getName()).thenReturn('b')
-        when(dependency3.getName()).thenReturn('a')
-        when(dependency4.getName()).thenReturn('c')
+        when(dependency1.getName()).thenReturn('b')
+        when(dependency2.getName()).thenReturn('a')
+        when(dependency3.getName()).thenReturn('c')
+        when(dependency4.getName()).thenReturn('a')
         when(standardPackagePathResolver.isStandardPackage(any(Path))).thenReturn(false)
     }
 
     void prepareGogradleDotLock() {
-        when(parser.parse([name: 'a', version: 'v1', transitive: false])).thenReturn(dependency1)
-        when(parser.parse([name: 'b', version: 'v2', transitive: false])).thenReturn(dependency2)
-        when(parser.parse([name: 'a', version: 'v2', transitive: false])).thenReturn(dependency3)
-        when(parser.parse([name: 'c', version: 'v3', transitive: false])).thenReturn(dependency4)
+        when(parser.parse([name: 'b', version: 'v2', transitive: false])).thenReturn(dependency1)
+        when(parser.parse([name: 'a', version: 'v1', transitive: false])).thenReturn(dependency2)
+        when(parser.parse([name: 'c', version: 'v3', transitive: false])).thenReturn(dependency3)
+        when(parser.parse([name: 'a', version: 'v2', transitive: false])).thenReturn(dependency4)
         IOUtils.write(project.getProjectDir(), LOCK_FILE_NAME, gogradleDotLock)
     }
 
@@ -116,10 +116,10 @@ dependencies:
     @Test
     void 'writing to gogradle.lock should succeed'() {
         // given
-        when(dependency1.toLockedNotation()).thenReturn([name: 'a', version: 'v1'])
-        when(dependency2.toLockedNotation()).thenReturn([name: 'b', version: 'v2'])
-        when(dependency3.toLockedNotation()).thenReturn([name: 'a', version: 'v2'])
-        when(dependency4.toLockedNotation()).thenReturn([name: 'c', version: 'v3'])
+        when(dependency1.toLockedNotation()).thenReturn([name: 'b', version: 'v2'])
+        when(dependency2.toLockedNotation()).thenReturn([name: 'a', version: 'v1'])
+        when(dependency3.toLockedNotation()).thenReturn([name: 'c', version: 'v3'])
+        when(dependency4.toLockedNotation()).thenReturn([name: 'a', version: 'v2'])
 
         // when
         manager.lock([dependency1, dependency2], [dependency3, dependency4])


### PR DESCRIPTION
I've noticed that when I'm adding a new dependency and trying to re-generate my lock file it's getting messed up. All deps are in a new random order.

This change makes dependencies in `gogradle.lock` always be sorted by name alphabetically which will make reviewing diffs for such changes much easier.