### PR TITLE
fully customizable go binary download url

### DIFF
--- a/docs/getting-started-cn.md
+++ b/docs/getting-started-cn.md
@@ -257,9 +257,9 @@ golang {
     // 可以用 goExecutable = 'IGNORE_LOCAL' 来强制指定不使用本地的go
     goExecutable = '/path/to/go/executable'
     
-    // 方便自定义仓库，Gogradle会尝试从
-    // http://my-company.com/go-distributions/go${version}.${os}-${arch}${extension} 下载go的发行版
-    goBinaryDownloadRootUri = 'http://my-company.com/go-distributions'
+    // 方便自定义仓库，Gogradle会尝试从以下地址下载Go的发行版
+    // http://golangtc.com/static/go/${version}/go${version}.${os}-${arch}${extension}
+    goBinaryDownloadTemplate == 'http://golangtc.com/static/go/${version}/go${version}.${os}-${arch}${extension}'
     
     // 默认为<go程序所在目录>/..
     goRoot = '/path/to/my/goroot'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -241,8 +241,8 @@ golang {
     goExecutable = '/path/to/go/executable'
     
     // For custom distribution repository. Gogradle will try to download go distributions from
-    // http://my-company.com/go-distributions/go${version}.${os}-${arch}${extension}
-    goBinaryDownloadRootUri = 'http://my-company.com/go-distributions'
+    // http://golangtc.com/static/go/${version}/go${version}.${os}-${arch}${extension}
+    goBinaryDownloadTemplate == 'http://golangtc.com/static/go/${version}/go${version}.${os}-${arch}${extension}'
 
     // If not set, GOROOT will be <directory of go binary>/..
     goRoot = '/path/to/my/goroot'

--- a/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
+++ b/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
@@ -130,12 +130,6 @@ public class GolangPluginSetting {
         this.goExecutable = goExecutable;
     }
 
-    /** @deprecated {@link #getGoBinaryDownloadTemplate} */
-    public boolean isFuckGfw() {
-        return BINARY_URL_GFW.equals(goBinaryDownloadTemplate);
-    }
-
-    /** @deprecated {@link #setGoBinaryDownloadTemplate} */
     public void setFuckGfw(boolean fuckGfw) {
         if (fuckGfw) {
             fuckGfw();
@@ -152,12 +146,18 @@ public class GolangPluginSetting {
         return goBinaryDownloadTemplate;
     }
 
-    /** @deprecated use {@link #setGoBinaryDownloadTemplate} */
+    /**
+     * @deprecated use {@link #setGoBinaryDownloadTemplate}
+     */
+    @Deprecated
     public void setGoBinaryDownloadBaseUri(String goBinaryDownloadBaseUri) {
         setGoBinaryDownloadBaseUri(goBinaryDownloadBaseUri == null ? null : URI.create(goBinaryDownloadBaseUri));
     }
 
-    /** @deprecated use {@link #setGoBinaryDownloadTemplate} */
+    /**
+     * @deprecated use {@link #setGoBinaryDownloadTemplate}
+     */
+    @Deprecated
     public void setGoBinaryDownloadBaseUri(URI goBinaryDownloadBaseUri) {
         setGoBinaryDownloadTemplate(goBinaryDownloadBaseUri == null ? null
                 : goBinaryDownloadBaseUri.resolve("/") + DefaultGoBinaryManager.FILENAME);

--- a/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
+++ b/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
@@ -18,6 +18,7 @@
 package com.github.blindpirate.gogradle;
 
 import com.github.blindpirate.gogradle.core.mode.BuildMode;
+import com.github.blindpirate.gogradle.crossplatform.DefaultGoBinaryManager;
 import com.github.blindpirate.gogradle.util.Assert;
 import com.github.blindpirate.gogradle.util.StringUtils;
 
@@ -48,6 +49,14 @@ import static com.github.blindpirate.gogradle.util.StringUtils.isNotBlank;
 @Singleton
 public class GolangPluginSetting {
 
+    // https://storage.googleapis.com/golang/go1.7.4.windows-386.zip
+    // https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz
+    private static final String BINARY_URL = "https://storage.googleapis.com/golang/" + DefaultGoBinaryManager.FILENAME;
+
+    // http://golangtc.com/static/go/1.7.4/go1.7.4.windows-386.zip
+    // http://golangtc.com/static/go/1.7.4/go1.7.4.linux-amd64.tar.gz
+    private static final String BINARY_URL_GFW = "http://golangtc.com/static/go/${version}/" + DefaultGoBinaryManager.FILENAME;
+
     private BuildMode buildMode = REPRODUCIBLE;
 
     private String packagePath;
@@ -59,12 +68,7 @@ public class GolangPluginSetting {
     private String goExecutable;
     private String goRoot;
 
-    // if true, the plugin will make its best effort to bypass the GFW
-    // designed for Chinese developer
-    private boolean fuckGfw;
-
-    // A user defined source for go binaries
-    private URI goBinaryDownloadRootUri;
+    private String goBinaryDownloadTemplate = BINARY_URL;
 
     public String getGoRoot() {
         return goRoot;
@@ -125,24 +129,47 @@ public class GolangPluginSetting {
         this.goExecutable = goExecutable;
     }
 
+    /** @deprecated {@link #getGoBinaryDownloadTemplate} */
     public boolean isFuckGfw() {
-        return fuckGfw;
+        return BINARY_URL_GFW.equals(goBinaryDownloadTemplate);
     }
 
+    /** @deprecated {@link #setGoBinaryDownloadTemplate} */
     public void setFuckGfw(boolean fuckGfw) {
-        this.fuckGfw = fuckGfw;
+        if(fuckGfw) {
+            fuckGfw();
+        }
+        else{
+            setGoBinaryDownloadTemplate(BINARY_URL);
+        }
     }
 
-    public URI getGoBinaryDownloadBaseUri() {
-        return goBinaryDownloadRootUri;
+    public void fuckGfw() {
+        goBinaryDownloadTemplate = BINARY_URL_GFW;
     }
 
+    public String getGoBinaryDownloadTemplate() {
+        return goBinaryDownloadTemplate;
+    }
+
+    /** @deprecated use {@link #setGoBinaryDownloadTemplate} */
     public void setGoBinaryDownloadBaseUri(String goBinaryDownloadBaseUri) {
         setGoBinaryDownloadBaseUri(goBinaryDownloadBaseUri == null ? null : URI.create(goBinaryDownloadBaseUri));
     }
 
-    public void setGoBinaryDownloadBaseUri(URI goBinaryDownloadBaseUrl) {
-        this.goBinaryDownloadRootUri = goBinaryDownloadBaseUrl;
+    /** @deprecated use {@link #setGoBinaryDownloadTemplate} */
+    public void setGoBinaryDownloadBaseUri(URI goBinaryDownloadBaseUri) {
+        setGoBinaryDownloadTemplate(goBinaryDownloadBaseUri == null ? null :
+                goBinaryDownloadBaseUri.resolve("/") + DefaultGoBinaryManager.FILENAME);
+    }
+
+    public void setGoBinaryDownloadTemplate(URI goBinaryDownloadTemplateUri) {
+        setGoBinaryDownloadTemplate(goBinaryDownloadTemplateUri == null ? null :
+                goBinaryDownloadTemplateUri.toASCIIString());
+    }
+
+    public void setGoBinaryDownloadTemplate(String goBinaryDownloadTemplate) {
+        this.goBinaryDownloadTemplate = goBinaryDownloadTemplate;
     }
 
     public void globalCacheFor(int duration, @Nonnull String timeUnit) {

--- a/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
+++ b/src/main/java/com/github/blindpirate/gogradle/GolangPluginSetting.java
@@ -55,7 +55,8 @@ public class GolangPluginSetting {
 
     // http://golangtc.com/static/go/1.7.4/go1.7.4.windows-386.zip
     // http://golangtc.com/static/go/1.7.4/go1.7.4.linux-amd64.tar.gz
-    private static final String BINARY_URL_GFW = "http://golangtc.com/static/go/${version}/" + DefaultGoBinaryManager.FILENAME;
+    private static final String BINARY_URL_GFW = "http://golangtc.com/static/go/${version}/"
+            + DefaultGoBinaryManager.FILENAME;
 
     private BuildMode buildMode = REPRODUCIBLE;
 
@@ -136,10 +137,9 @@ public class GolangPluginSetting {
 
     /** @deprecated {@link #setGoBinaryDownloadTemplate} */
     public void setFuckGfw(boolean fuckGfw) {
-        if(fuckGfw) {
+        if (fuckGfw) {
             fuckGfw();
-        }
-        else{
+        } else {
             setGoBinaryDownloadTemplate(BINARY_URL);
         }
     }
@@ -159,13 +159,13 @@ public class GolangPluginSetting {
 
     /** @deprecated use {@link #setGoBinaryDownloadTemplate} */
     public void setGoBinaryDownloadBaseUri(URI goBinaryDownloadBaseUri) {
-        setGoBinaryDownloadTemplate(goBinaryDownloadBaseUri == null ? null :
-                goBinaryDownloadBaseUri.resolve("/") + DefaultGoBinaryManager.FILENAME);
+        setGoBinaryDownloadTemplate(goBinaryDownloadBaseUri == null ? null
+                : goBinaryDownloadBaseUri.resolve("/") + DefaultGoBinaryManager.FILENAME);
     }
 
     public void setGoBinaryDownloadTemplate(URI goBinaryDownloadTemplateUri) {
-        setGoBinaryDownloadTemplate(goBinaryDownloadTemplateUri == null ? null :
-                goBinaryDownloadTemplateUri.toASCIIString());
+        setGoBinaryDownloadTemplate(goBinaryDownloadTemplateUri == null ? null
+                : goBinaryDownloadTemplateUri.toASCIIString());
     }
 
     public void setGoBinaryDownloadTemplate(String goBinaryDownloadTemplate) {

--- a/src/main/java/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManager.java
+++ b/src/main/java/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManager.java
@@ -239,6 +239,7 @@ public class DefaultGoBinaryManager implements GoBinaryManager {
         String archiveFileName = injectVariables(FILENAME, version);
         File goBinaryCachePath = globalCacheManager.getGlobalGoBinCacheDir(archiveFileName);
         forceMkdir(goBinaryCachePath.getParentFile());
+        LOGGER.warn("downloading {} -> {}", url, goBinaryCachePath.getAbsolutePath());
         try {
             httpUtils.download(url, goBinaryCachePath.toPath());
         } catch (IOException e) {

--- a/src/test/groovy/com/github/blindpirate/gogradle/GolangPluginSettingTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/GolangPluginSettingTest.groovy
@@ -104,9 +104,9 @@ class GolangPluginSettingTest {
     }
 
     @Test
-    void 'setting fuckGfw should succeed (backwards compatiblity)'() {
+    void 'setting fuckGfw should succeed'() {
         setting.fuckGfw = true
-        assert setting.fuckGfw
+        assert setting.goBinaryDownloadTemplate == 'http://golangtc.com/static/go/${version}/go${version}.${os}-${arch}${extension}'
     }
 
     @Test

--- a/src/test/groovy/com/github/blindpirate/gogradle/GolangPluginSettingTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/GolangPluginSettingTest.groovy
@@ -104,21 +104,40 @@ class GolangPluginSettingTest {
     }
 
     @Test
-    void 'setting fuckGfw should succeed'() {
+    void 'setting fuckGfw should succeed (backwards compatiblity)'() {
         setting.fuckGfw = true
         assert setting.fuckGfw
     }
 
     @Test
-    void 'setting go binary download base uri to a String should succeed'() {
-        setting.goBinaryDownloadBaseUri = 'http://example.com/'
-        assert setting.goBinaryDownloadBaseUri == URI.create('http://example.com/')
+    void 'setting fuckGfw changes the binary download uri'() {
+        def before = setting.goBinaryDownloadTemplate
+        setting.fuckGfw()
+        assert before != setting.goBinaryDownloadTemplate
     }
 
     @Test
-    void 'setting go binary download base uri to a URI should succeed'() {
+    void 'setting go binary download base uri to a String should succeed (backwards compatiblity)'() {
+        setting.goBinaryDownloadBaseUri = 'http://example.com/'
+        assert setting.goBinaryDownloadTemplate == 'http://example.com/go${version}.${os}-${arch}${extension}'
+    }
+
+    @Test
+    void 'setting go binary download base uri to a URI should succeed (backwards compatiblity)'() {
         setting.goBinaryDownloadBaseUri = URI.create('http://example.com/')
-        assert setting.goBinaryDownloadBaseUri == URI.create('http://example.com/')
+        assert setting.goBinaryDownloadTemplate == 'http://example.com/go${version}.${os}-${arch}${extension}'
+    }
+
+    @Test
+    void 'setting go binary download uri to a URI should succeed'() {
+        setting.goBinaryDownloadTemplate = URI.create('http://example.com/wherever?youName=it')
+        assert setting.goBinaryDownloadTemplate == 'http://example.com/wherever?youName=it'
+    }
+
+    @Test
+    void 'setting go binary download uri to a String should succeed'() {
+        setting.goBinaryDownloadTemplate = 'http://example.com/wherever?youName=it'
+        assert setting.goBinaryDownloadTemplate == 'http://example.com/wherever?youName=it'
     }
 
     @Test

--- a/src/test/groovy/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManagerTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/crossplatform/DefaultGoBinaryManagerTest.groovy
@@ -62,6 +62,7 @@ class DefaultGoBinaryManagerTest extends MockEnvironmentVariableSupport {
     void setUp() {
         Process process = mock(Process)
         when(setting.getGoExecutable()).thenReturn("go")
+        when(setting.getGoBinaryDownloadTemplate()).thenReturn('http://example.com/go${version}.${os}-${arch}${extension}')
         when(processUtils.run(['go', 'version'], null, null)).thenReturn(process)
         when(processUtils.getResult(process)).thenReturn(processResult)
 
@@ -217,7 +218,6 @@ class DefaultGoBinaryManagerTest extends MockEnvironmentVariableSupport {
     void 'go binary with specified version should be downloaded when a modified go binary base url has been set'() {
         // given
         when(setting.getGoVersion()).thenReturn('1.7.4')
-        when(setting.getGoBinaryDownloadBaseUri()).thenReturn(URI.create('http://example.com/'))
         // then
         assert manager.getBinaryPath() == resource.toPath().resolve("1.7.4/go/bin/go${Os.getHostOs().exeExtension()}")
         assert manager.getGoVersion() == '1.7.4'


### PR DESCRIPTION
Allows to configure a go binary download url template (instead of only specifying the basepath and having a fixed url name). Adds a new gogradle setting like:
```
golang {
	setGoBinaryDownloadTemplate 'http://example.com/dl/${version}/whatever-${version}-${os}-${arch}${extension}'
}
```
Required for example to download go bin from a company internal network where the url does not end with `go${version}.${os}-${arch}${extension}`. Change remains backwards compatible.