### PR TITLE
fix go tool <cmd> crash with buildTags set

### DIFF
--- a/src/main/java/com/github/blindpirate/gogradle/build/DefaultBuildManager.java
+++ b/src/main/java/com/github/blindpirate/gogradle/build/DefaultBuildManager.java
@@ -157,12 +157,14 @@ public class DefaultBuildManager implements BuildManager {
             return cmd;
         }
 
+        // support: go tool vet -tags whatever packag
+        int tagsOffset = "tool".equals(cmd.get(0)) ? 2 : 1;
         List<String> ret = new ArrayList<>(cmd);
         // https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies
-        ret.add(1, "-tags");
+        ret.add(tagsOffset, "-tags");
 
         String tagsArg = setting.getBuildTags().stream().collect(Collectors.joining(" "));
-        ret.add(2, "'" + tagsArg + "'");
+        ret.add(tagsOffset + 1, "'" + tagsArg + "'");
         return ret;
     }
 

--- a/src/test/groovy/com/github/blindpirate/gogradle/build/DefaultBuildManagerTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/build/DefaultBuildManagerTest.groovy
@@ -226,6 +226,7 @@ class DefaultBuildManagerTest extends MockEnvironmentVariableSupport {
         assert manager.insertBuildTags([]) == []
         assert manager.insertBuildTags(['build']) == ['build', '-tags', "'a b c'"]
         assert manager.insertBuildTags(['build', 'package']) == ['build', '-tags', "'a b c'", 'package']
+        assert manager.insertBuildTags(['tool', 'vet', 'package']) == ['tool', 'vet', '-tags', "'a b c'", 'package']
     }
 
     @Test(expected = BuildException)


### PR DESCRIPTION
This PR fixes the issue that whenever you had `golang.buildTags` set, all the tasks relying on `go tool` would crash (like GoVet, GoCover, ...), since `go tool -tags 'whatever' vet pkg` is not a valid command.
It explicitly checks for 'tool' as a go argument and shifts the tags by an additonal position, such that the command becomes `go tool vet -tags 'whatever' pkg`