### PR TITLE
Fix dep toml

### DIFF
--- a/src/integration-test/groovy/com/github/blindpirate/gogradle/issues/RecognizeGopkgLockIntegrationTest.groovy
+++ b/src/integration-test/groovy/com/github/blindpirate/gogradle/issues/RecognizeGopkgLockIntegrationTest.groovy
@@ -1,0 +1,40 @@
+package com.github.blindpirate.gogradle.issues
+
+import com.github.blindpirate.gogradle.GogradleRunner
+import com.github.blindpirate.gogradle.support.AccessWeb
+import com.github.blindpirate.gogradle.support.IntegrationTestSupport
+import com.github.blindpirate.gogradle.support.WithMockGo
+import com.github.blindpirate.gogradle.support.WithResource
+import com.github.blindpirate.gogradle.util.IOUtils
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@WithResource
+@RunWith(GogradleRunner)
+@WithMockGo
+@AccessWeb
+class RecognizeGopkgLockIntegrationTest extends IntegrationTestSupport {
+    // https://github.com/gogradle/gogradle/issues/221
+    // https://github.com/census-instrumentation/opencensus-go/blob/0edc045e110a4ba034ed03dffbbaf13eeae8b25b/Gopkg.lock
+    @Test
+    void "can recognize Gopkg.lock's source"() {
+        writeBuildAndSettingsDotGradle(buildDotGradleBase)
+        IOUtils.write(resource, 'Gopkg.lock', '''
+[[projects]]
+  branch = "master"
+  name = "git.apache.org/thrift.git"
+  packages = ["lib/go/thrift"]
+  revision = "606f1ef31447526b908244933d5b716397a6bad8"
+  source = "github.com/apache/thrift"
+''')
+        newBuild('init')
+        newBuild('vendor')
+
+        assert new File(resource, 'vendor/git.apache.org/thrift.git').exists()
+    }
+
+    @Override
+    File getProjectRoot() {
+        return resource
+    }
+}

--- a/src/main/java/com/github/blindpirate/gogradle/core/cache/PersistenceNotationToResolvedCache.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/cache/PersistenceNotationToResolvedCache.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.github.blindpirate.gogradle.GogradleGlobal.GOGRADLE_COMPATIBLE_VERSION;
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.AllPackagePathResolvers;
 
 @Singleton
 public class PersistenceNotationToResolvedCache
@@ -38,7 +39,8 @@ public class PersistenceNotationToResolvedCache
     private final PackagePathResolver packagePathResolver;
 
     @Inject
-    public PersistenceNotationToResolvedCache(Project project, PackagePathResolver packagePathResolver) {
+    public PersistenceNotationToResolvedCache(Project project,
+                                              @AllPackagePathResolvers PackagePathResolver packagePathResolver) {
         super(project, "PersistenceNotationToResolvedCache-" + GOGRADLE_COMPATIBLE_VERSION + ".bin");
         this.packagePathResolver = packagePathResolver;
     }

--- a/src/main/java/com/github/blindpirate/gogradle/core/cache/PersistenceResolvedToDependenciesCache.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/cache/PersistenceResolvedToDependenciesCache.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.github.blindpirate.gogradle.GogradleGlobal.GOGRADLE_COMPATIBLE_VERSION;
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.AllPackagePathResolvers;
 
 
 @Singleton
@@ -40,7 +41,8 @@ public class PersistenceResolvedToDependenciesCache
     private final PackagePathResolver packagePathResolver;
 
     @Inject
-    public PersistenceResolvedToDependenciesCache(Project project, PackagePathResolver packagePathResolver) {
+    public PersistenceResolvedToDependenciesCache(Project project,
+                                                  @AllPackagePathResolvers PackagePathResolver packagePathResolver) {
         super(project, "PersistenceResolvedToDependenciesCache-"
                 + GOGRADLE_COMPATIBLE_VERSION + ".bin");
         this.packagePathResolver = packagePathResolver;

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/parse/DefaultMapNotationParser.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/parse/DefaultMapNotationParser.java
@@ -28,6 +28,7 @@ import com.github.blindpirate.gogradle.core.dependency.NotationDependency;
 import com.github.blindpirate.gogradle.core.dependency.UnrecognizedNotationDependency;
 import com.github.blindpirate.gogradle.core.exceptions.DependencyResolutionException;
 import com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver;
+import com.github.blindpirate.gogradle.core.pack.PackagePathResolver;
 import com.github.blindpirate.gogradle.util.Assert;
 import com.github.blindpirate.gogradle.util.MapUtils;
 import com.github.blindpirate.gogradle.util.StringUtils;
@@ -38,6 +39,7 @@ import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.AllPackagePathResolvers;
 import static com.github.blindpirate.gogradle.util.MapUtils.getString;
 import static com.github.blindpirate.gogradle.vcs.VcsNotationDependency.URLS_KEY;
 import static com.github.blindpirate.gogradle.vcs.VcsNotationDependency.URL_KEY;
@@ -56,10 +58,10 @@ public class DefaultMapNotationParser implements MapNotationParser {
     @Inject
     public DefaultMapNotationParser(DirMapNotationParser dirMapNotationParser,
                                     VendorMapNotationParser vendorMapNotationParser,
-                                    DefaultPackagePathResolver packagePathResolver) {
+                                    @AllPackagePathResolvers PackagePathResolver packagePathResolver) {
         this.dirMapNotationParser = dirMapNotationParser;
         this.vendorMapNotationParser = vendorMapNotationParser;
-        this.packagePathResolver = packagePathResolver;
+        this.packagePathResolver = (DefaultPackagePathResolver) packagePathResolver;
     }
 
     @Override

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/parse/DefaultNotationConverter.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/parse/DefaultNotationConverter.java
@@ -28,12 +28,14 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Map;
 
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.AllPackagePathResolvers;
+
 @Singleton
 public class DefaultNotationConverter implements NotationConverter {
     private final PackagePathResolver packagePathResolver;
 
     @Inject
-    public DefaultNotationConverter(PackagePathResolver packagePathResolver) {
+    public DefaultNotationConverter(@AllPackagePathResolvers PackagePathResolver packagePathResolver) {
         this.packagePathResolver = packagePathResolver;
     }
 

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/ExternalDependencyFactory.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/ExternalDependencyFactory.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static com.github.blindpirate.gogradle.core.GolangConfiguration.BUILD;
 import static com.github.blindpirate.gogradle.core.GolangConfiguration.TEST;
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.AllPackagePathResolvers;
 import static com.github.blindpirate.gogradle.util.DependencySetUtils.parseMany;
 import static com.github.blindpirate.gogradle.util.StringUtils.pathStartsWith;
 import static com.google.common.collect.ImmutableMap.of;
@@ -48,6 +49,7 @@ public abstract class ExternalDependencyFactory {
     protected MapNotationParser mapNotationParser;
 
     @Inject
+    @AllPackagePathResolvers
     protected PackagePathResolver packagePathResolver;
 
     @Inject

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/FirstPassVendorDirectoryVisitor.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/FirstPassVendorDirectoryVisitor.java
@@ -38,8 +38,7 @@ public class FirstPassVendorDirectoryVisitor extends SimpleFileVisitor<Path> {
 
     private final Path parentVendor;
 
-    public FirstPassVendorDirectoryVisitor(Path parentVendor,
-                                           PackagePathResolver packagePathResolver) {
+    public FirstPassVendorDirectoryVisitor(Path parentVendor, PackagePathResolver packagePathResolver) {
         this.packagePathResolver = packagePathResolver;
         this.parentVendor = parentVendor;
     }

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/SourceCodeDependencyFactory.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/SourceCodeDependencyFactory.java
@@ -27,6 +27,7 @@ import com.github.blindpirate.gogradle.core.dependency.GolangDependency;
 import com.github.blindpirate.gogradle.core.dependency.GolangDependencySet;
 import com.github.blindpirate.gogradle.core.dependency.ResolvedDependency;
 import com.github.blindpirate.gogradle.core.dependency.parse.NotationParser;
+import com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver;
 import com.github.blindpirate.gogradle.core.pack.PackagePathResolver;
 
 import javax.inject.Inject;
@@ -36,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.*;
 import static com.github.blindpirate.gogradle.util.StringUtils.isBlank;
 
 /**
@@ -52,10 +54,11 @@ public class SourceCodeDependencyFactory {
     private final GogradleRootProject gogradleRootProject;
 
     @Inject
-    public SourceCodeDependencyFactory(PackagePathResolver packagePathResolver,
-                                       NotationParser notationParser,
-                                       GoImportExtractor goImportExtractor,
-                                       GogradleRootProject gogradleRootProject) {
+    public SourceCodeDependencyFactory(
+            @AllPackagePathResolvers PackagePathResolver packagePathResolver,
+            NotationParser notationParser,
+            GoImportExtractor goImportExtractor,
+            GogradleRootProject gogradleRootProject) {
         this.packagePathResolver = packagePathResolver;
         this.notationParser = notationParser;
         this.goImportExtractor = goImportExtractor;

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/SourceCodeDependencyFactory.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/SourceCodeDependencyFactory.java
@@ -27,7 +27,6 @@ import com.github.blindpirate.gogradle.core.dependency.GolangDependency;
 import com.github.blindpirate.gogradle.core.dependency.GolangDependencySet;
 import com.github.blindpirate.gogradle.core.dependency.ResolvedDependency;
 import com.github.blindpirate.gogradle.core.dependency.parse.NotationParser;
-import com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver;
 import com.github.blindpirate.gogradle.core.pack.PackagePathResolver;
 
 import javax.inject.Inject;
@@ -37,7 +36,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.*;
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.AllPackagePathResolvers;
 import static com.github.blindpirate.gogradle.util.StringUtils.isBlank;
 
 /**

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/VendorDependencyFactory.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/VendorDependencyFactory.java
@@ -28,6 +28,8 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.nio.file.Path;
 
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.AllPackagePathResolvers;
+
 
 /**
  * A {@link VendorDependencyFactory} is a factory that reads vendor directory and resolves them to
@@ -40,7 +42,7 @@ public class VendorDependencyFactory {
     private final PackagePathResolver packagePathResolver;
 
     @Inject
-    public VendorDependencyFactory(PackagePathResolver packagePathResolver) {
+    public VendorDependencyFactory(@AllPackagePathResolvers PackagePathResolver packagePathResolver) {
         this.packagePathResolver = packagePathResolver;
     }
 

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/external/dep/DepDependencyFactory.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/external/dep/DepDependencyFactory.java
@@ -32,6 +32,6 @@ public class DepDependencyFactory extends ExternalDependencyFactory {
 
     @Override
     protected List<Map<String, Object>> adapt(File file) {
-        return GopkgDotLockModel.parse(file);
+        return GopkgDotLockModel.parse(originalPackagePathResolver, file);
     }
 }

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/external/dep/DepDependencyFactory.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/external/dep/DepDependencyFactory.java
@@ -1,11 +1,15 @@
 package com.github.blindpirate.gogradle.core.dependency.produce.external.dep;
 
 import com.github.blindpirate.gogradle.core.dependency.produce.ExternalDependencyFactory;
+import com.github.blindpirate.gogradle.core.pack.PackagePathResolver;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+
+import static com.github.blindpirate.gogradle.core.pack.DefaultPackagePathResolver.OriginalPackagePathResolvers;
 
 /**
  * Converts Gopkg.lock in repos managed by dep to gogradle map notations.
@@ -14,6 +18,13 @@ import java.util.Map;
  */
 @Singleton
 public class DepDependencyFactory extends ExternalDependencyFactory {
+    private final PackagePathResolver originalPackagePathResolver;
+
+    @Inject
+    public DepDependencyFactory(@OriginalPackagePathResolvers PackagePathResolver originalPackagePathResolver) {
+        this.originalPackagePathResolver = originalPackagePathResolver;
+    }
+
     @Override
     public String identityFileName() {
         return "Gopkg.lock";

--- a/src/main/java/com/github/blindpirate/gogradle/core/pack/DefaultPackagePathResolver.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/pack/DefaultPackagePathResolver.java
@@ -18,6 +18,7 @@
 package com.github.blindpirate.gogradle.core.pack;
 
 import com.github.blindpirate.gogradle.core.GolangPackage;
+import com.github.blindpirate.gogradle.util.CollectionUtils;
 import com.github.blindpirate.gogradle.util.FactoryUtil;
 import com.github.blindpirate.gogradle.util.logging.DebugLog;
 import com.google.inject.BindingAnnotation;
@@ -46,8 +47,8 @@ public class DefaultPackagePathResolver implements PackagePathResolver {
     private final List<PackagePathResolver> delegates;
 
     @Inject
-    public DefaultPackagePathResolver(@PackagePathResolvers List<PackagePathResolver> delegates) {
-        this.delegates = delegates;
+    public DefaultPackagePathResolver(PackagePathResolver... delegates) {
+        this.delegates = CollectionUtils.immutableList(delegates);
     }
 
     @Override
@@ -85,6 +86,12 @@ public class DefaultPackagePathResolver implements PackagePathResolver {
     @BindingAnnotation
     @Target({FIELD, PARAMETER, METHOD})
     @Retention(RUNTIME)
-    public @interface PackagePathResolvers {
+    public @interface AllPackagePathResolvers {
+    }
+
+    @BindingAnnotation
+    @Target({FIELD, PARAMETER, METHOD})
+    @Retention(RUNTIME)
+    public @interface OriginalPackagePathResolvers {
     }
 }

--- a/src/main/java/com/github/blindpirate/gogradle/vcs/VcsScheme.java
+++ b/src/main/java/com/github/blindpirate/gogradle/vcs/VcsScheme.java
@@ -18,6 +18,10 @@ public enum VcsScheme {
         this.scheme = scheme;
     }
 
+    public String getScheme() {
+        return scheme;
+    }
+
     public String buildUrl(String packagePath) {
         return scheme + packagePath;
     }

--- a/src/test/groovy/com/github/blindpirate/gogradle/core/dependency/produce/external/dep/DepDependencyFactoryTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/core/dependency/produce/external/dep/DepDependencyFactoryTest.groovy
@@ -19,6 +19,7 @@ package com.github.blindpirate.gogradle.core.dependency.produce.external.dep
 
 import com.github.blindpirate.gogradle.GogradleRunner
 import com.github.blindpirate.gogradle.core.dependency.produce.external.AbstractExternalDependencyFactoryTest
+import com.github.blindpirate.gogradle.core.pack.GithubGitlabPackagePathResolver
 import com.github.blindpirate.gogradle.support.WithResource
 import com.github.blindpirate.gogradle.util.IOUtils
 import org.junit.Test
@@ -28,7 +29,7 @@ import org.mockito.InjectMocks
 @RunWith(GogradleRunner)
 class DepDependencyFactoryTest extends AbstractExternalDependencyFactoryTest {
     @InjectMocks
-    DepDependencyFactory depDependencyFactory
+    DepDependencyFactory depDependencyFactory = new DepDependencyFactory(new GithubGitlabPackagePathResolver('github.com'))
 
     @Test
     @WithResource('')
@@ -47,7 +48,9 @@ class DepDependencyFactoryTest extends AbstractExternalDependencyFactoryTest {
         verifyMapParsed([name       : "github.com/Masterminds/vcs",
                          subpackages: ['...'],
                          commit     : '3084677c2c188840777bff30054f2b553729d329',
-                         tag        : "v1.11.1"])
+                         tag        : "v1.11.1",
+                         vcs        : "git",
+                         urls       : ['https://github.com/Masterminds/vcs.git', 'git@github.com:Masterminds/vcs.git']])
         verifyMapParsed([name       : "github.com/armon/go-radix",
                          branch     : 'master',
                          subpackages: ['...'],
@@ -73,6 +76,7 @@ class DepDependencyFactoryTest extends AbstractExternalDependencyFactoryTest {
   packages = ["."]
   revision = "3084677c2c188840777bff30054f2b553729d329"
   version = "v1.11.1"
+  source = "github.com/Masterminds/vcs"
 
 [[projects]]
   branch = "master"

--- a/src/test/groovy/com/github/blindpirate/gogradle/core/pack/DefaultPackagePathResolverTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/core/pack/DefaultPackagePathResolverTest.groovy
@@ -52,7 +52,7 @@ class DefaultPackagePathResolverTest {
 
     @Before
     void setUp() {
-        resolver = new DefaultPackagePathResolver([resolver1, resolver2])
+        resolver = new DefaultPackagePathResolver(resolver1, resolver2)
         when(resolver1.produce(packagePath)).thenReturn(empty())
         when(resolver2.produce(packagePath)).thenReturn(of(packageInfo))
     }


### PR DESCRIPTION
This PR fixes #221 

Previously we didn't recognize `source` field in `Gopkg.lock` correctly.