### PR TITLE
[gogradle-225] Fix OverlappingFileLockException resolving dependencies

### DIFF
--- a/src/main/java/com/github/blindpirate/gogradle/core/cache/DefaultGlobalCacheManager.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/cache/DefaultGlobalCacheManager.java
@@ -36,6 +36,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
@@ -198,6 +199,8 @@ public class DefaultGlobalCacheManager implements GlobalCacheManager {
         try {
             return doGetMetadata(packagePath);
         } catch (IOException e) {
+            return Optional.empty();
+        } catch (OverlappingFileLockException e) {
             return Optional.empty();
         }
     }

--- a/src/test/groovy/com/github/blindpirate/gogradle/core/cache/DefaultGlobalCacheManagerTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/core/cache/DefaultGlobalCacheManagerTest.groovy
@@ -258,6 +258,15 @@ repositories:
         assert !cacheManager.getMetadata(Paths.get('github.com/user/package')).isPresent()
     }
 
+    @Test
+    void 'empty result should be returned if the file is already locked in metadata reading'() {
+        File lockFile = new File(resource, 'go/repo/github.com/user/lock/gogradle-metadata')
+        write(lockFile, getMetadataYaml(System.currentTimeMillis()))
+        FileLock lock = new RandomAccessFile(lockFile.absolutePath, "rw").getChannel().lock()
+        assert !cacheManager.getMetadata(Paths.get('github.com/user/lock')).isPresent()
+        lock.release()
+    }
+
     class LockProcess {
         static void main(String[] args) {
             FileChannel channel = null


### PR DESCRIPTION
Fix for https://github.com/gogradle/gogradle/issues/225 by catching the OverlappingFileLockException similar to IOException.

@blindpirate - does this make sense?