### PR TITLE
Ignore symbolic link when copying dependencies

### DIFF
--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/install/DependencyInstallFileFilter.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/install/DependencyInstallFileFilter.java
@@ -22,6 +22,7 @@ import com.github.blindpirate.gogradle.util.IOUtils;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 
@@ -47,12 +48,13 @@ public class DependencyInstallFileFilter implements FileFilter {
 
     @Override
     public boolean accept(File pathname) {
-        if (pathname.isDirectory()) {
+        if (Files.isSymbolicLink(pathname.toPath())) {
+            return false;
+        } else if (pathname.isDirectory()) {
             return acceptDirectory(pathname);
         } else if (pathname.isFile()) {
             return inSubpackagesPredicate.test(pathname) && acceptFile(pathname);
         } else {
-            // symbolic links
             return false;
         }
     }

--- a/src/test/groovy/com/github/blindpirate/gogradle/core/dependency/install/DependencyInstallFileFilterTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/core/dependency/install/DependencyInstallFileFilterTest.groovy
@@ -24,6 +24,9 @@ import com.github.blindpirate.gogradle.util.IOUtils
 import org.junit.Test
 import org.junit.runner.RunWith
 
+import java.nio.file.Files
+import java.nio.file.Paths
+
 @RunWith(GogradleRunner)
 @WithResource('')
 class DependencyInstallFileFilterTest extends FileFilterTest {
@@ -46,7 +49,6 @@ class DependencyInstallFileFilterTest extends FileFilterTest {
             assert !filter.accept(touch(it))
         }
     }
-
 
     @Test
     void '*_test_go should be rejected'() {
@@ -85,6 +87,20 @@ class DependencyInstallFileFilterTest extends FileFilterTest {
         IOUtils.write(resource, '_main.go', '')
 
         assert !allDescendentFilter.accept(resource)
+    }
+
+    @Test
+    void 'relative symlink should be rejected'() {
+        Files.createSymbolicLink(resource.toPath().resolve('link'), Paths.get(".."))
+
+        assert !allDescendentFilter.accept(new File(resource, 'link'))
+    }
+
+    @Test
+    void 'absolute symlink should be rejected'() {
+        Files.createSymbolicLink(resource.toPath().resolve('link'), resource.toPath())
+
+        assert !allDescendentFilter.accept(new File(resource, 'link'))
     }
 
     @Test


### PR DESCRIPTION
This fixes https://github.com/gogradle/gogradle/issues/274

Previously, due to an implementation defect, we copy symbolic links when installing dependencies.
This PR fixes this issue.