### PR TITLE
Fix issue of parsing parameterized test output

### DIFF
--- a/src/main/java/com/github/blindpirate/gogradle/task/go/test/AbstractGoTestResultExtractor.java
+++ b/src/main/java/com/github/blindpirate/gogradle/task/go/test/AbstractGoTestResultExtractor.java
@@ -91,10 +91,21 @@ public abstract class AbstractGoTestResultExtractor implements GoTestResultExtra
         return testFileContents
                 .entrySet()
                 .stream()
-                .filter(entry -> entry.getValue().contains(methodName))
+                .filter(entry -> testFileContainsTestMethodName(entry, methodName))
                 .findFirst()
                 .get()
                 .getKey();
+    }
+
+    private boolean testFileContainsTestMethodName(Map.Entry<File, String> entry, String methodName) {
+        // methodName can be paramterized, e.g. Test_keyLessThan/a<b
+        // we simply remove all characters after '/'
+        int indexOfSlash = methodName.indexOf('/');
+        if (indexOfSlash == -1) {
+            return entry.getValue().contains(methodName);
+        } else {
+            return entry.getValue().contains(methodName.substring(0, indexOfSlash));
+        }
     }
 
     private boolean stdoutContains(PackageTestResult result, String error) {

--- a/src/main/java/com/github/blindpirate/gogradle/task/go/test/PlainGoTestResultExtractor.java
+++ b/src/main/java/com/github/blindpirate/gogradle/task/go/test/PlainGoTestResultExtractor.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 import static com.github.blindpirate.gogradle.util.DateUtils.toMilliseconds;
 import static java.lang.Double.parseDouble;
 
+@Deprecated
 public class PlainGoTestResultExtractor extends AbstractGoTestResultExtractor {
     private static final Map<String, TestResult.ResultType> RESULT_TYPE_MAP =
             ImmutableMap.of("PASS", TestResult.ResultType.SUCCESS,

--- a/src/test/resources/go-test-cover/e/e_test.go
+++ b/src/test/resources/go-test-cover/e/e_test.go
@@ -1,0 +1,32 @@
+package e
+
+import "testing"
+
+func Test_Parameterized(t *testing.T) {
+    data := []struct {
+        name string
+        value int32
+    }{
+        {
+            name: "success1",
+            value: 1,
+        },
+        {
+            name: "/success2",
+            value: 2,
+        },
+        {
+            name: ">success3",
+            value: 3,
+        },
+    }
+
+    for n:= range data {
+        index := n
+        t.Run(data[index].name, func(t *testing.T) {
+            if(data[index].value > 3) {
+                t.Fail()
+            }
+        })
+    }
+}

--- a/src/test/resources/go-test-cover/e/e_test.go.fail
+++ b/src/test/resources/go-test-cover/e/e_test.go.fail
@@ -1,0 +1,36 @@
+package e
+
+import "testing"
+
+func Test_Parameterized(t *testing.T) {
+    data := []struct {
+        name string
+        value int32
+    }{
+        {
+            name: "success1",
+            value: 1,
+        },
+        {
+            name: "/success2",
+            value: 2,
+        },
+        {
+            name: ">success3",
+            value: 3,
+        },
+        {
+            name: "fail",
+            value: 4,
+        },
+    }
+
+    for n:= range data {
+        index := n
+        t.Run(data[index].name, func(t *testing.T) {
+            if(data[index].value > 3) {
+                t.Fail()
+            }
+        })
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/gogradle/gogradle/issues/276.

Previously, we didn't handle parameterized test JSON output properly. This PR recognizes parameterized test output and converts them to normal test method names.