### PR TITLE
Allow absolute output location

### DIFF
--- a/src/integration-test/groovy/com/github/blindpirate/gogradle/GoBuildIntegrationTest.groovy
+++ b/src/integration-test/groovy/com/github/blindpirate/gogradle/GoBuildIntegrationTest.groovy
@@ -141,6 +141,34 @@ func main(){
         assert !stdout.toString().contains(':buildLinux386 UP-TO-DATE')
     }
 
+    // https://github.com/gogradle/gogradle/issues/279
+    @Test
+    void 'can set absolute output location'() {
+        appendOnBuildDotGradle('''
+            goBuild {
+                outputLocation = project.buildDir.absolutePath + '/result/${PROJECT_NAME}-${PROJECT_VERSION}-${GOOS}-${GOARCH}'
+            }
+            
+            task clean {
+                doLast { delete project.buildDir }
+            }
+            ''')
+
+        newBuild('goBuild')
+
+        assert !buildUpToDate()
+        assert new File(resource, 'build/result').listFiles().size() == 1
+
+        newBuild('clean')
+
+        assert !new File(resource, 'build').exists()
+
+        newBuild('goBuild')
+
+        assert !buildUpToDate()
+        assert new File(resource, 'build/result').listFiles().size() == 1
+    }
+
     @Test
     void 'build with build tags should succeed'() {
         appendOnBuildDotGradle('''

--- a/src/main/java/com/github/blindpirate/gogradle/task/go/GoBuild.java
+++ b/src/main/java/com/github/blindpirate/gogradle/task/go/GoBuild.java
@@ -106,7 +106,8 @@ public class GoBuild extends Go {
             subTask.getInputs().files((Callable<Collection<File>>)
                     () -> GoSourceCodeFilter.filterGoFiles(getProjectDir(), PROJECT_AND_VENDOR_BUILD_FILES));
 
-            subTask.getOutputs().file(new File(getProjectDir(), getRenderedOutputLocation(os, arch)));
+
+            subTask.getOutputs().file(getRenderedOutputLocation(os, arch));
 
             Map<String, Object> inputProperties = new HashMap<>();
             inputProperties.put("buildTags", (Callable<List<String>>) () -> setting.getBuildTags());
@@ -116,11 +117,18 @@ public class GoBuild extends Go {
         }
     }
 
-    private String getRenderedOutputLocation(Os os, Arch arch) {
+    private File getRenderedOutputLocation(Os os, Arch arch) {
         Map<String, Object> context = new HashMap<>(getEffectiveEnvironment(os, arch));
         context.put("PROJECT_NAME", getProject().getName());
         context.put("PROJECT_VERSION", getProject().getVersion());
-        return StringUtils.render(getOutputLocation(), context);
+        String renderedOutputLocation = StringUtils.render(getOutputLocation(), context);
+
+        File result = new File(renderedOutputLocation);
+        if (result.isAbsolute()) {
+            return result;
+        } else {
+            return new File(getProjectDir(), renderedOutputLocation);
+        }
     }
 
     public String getOutputLocation() {

--- a/src/main/java/com/github/blindpirate/gogradle/task/go/GoBuild.java
+++ b/src/main/java/com/github/blindpirate/gogradle/task/go/GoBuild.java
@@ -106,7 +106,6 @@ public class GoBuild extends Go {
             subTask.getInputs().files((Callable<Collection<File>>)
                     () -> GoSourceCodeFilter.filterGoFiles(getProjectDir(), PROJECT_AND_VENDOR_BUILD_FILES));
 
-
             subTask.getOutputs().file(getRenderedOutputLocation(os, arch));
 
             Map<String, Object> inputProperties = new HashMap<>();


### PR DESCRIPTION
### Context

As reported by https://github.com/gogradle/gogradle/issues/279 , previously, if a build declares absolute output location, e.g.

```
outputLocation = "${project.buildDir}" + '/myproject${GOEXE}'
```

The task output would be [incorrectly registered](https://github.com/gogradle/gogradle/blob/a476d1509e2d6a62ea5dd7ed6d6ff99a7f093c79/src/main/java/com/github/blindpirate/gogradle/task/go/GoBuild.java#L109):

```
subTask.getOutputs().file(new File(getProjectDir(), getRenderedOutputLocation(os, arch))); // Ignore the fact of outputLocation being absolute
```

This PR fixes by recognizing absolute `outputLocation`.