### PR TITLE
Remove `tool` from the `go vet` call.

### DIFF
--- a/src/main/java/com/github/blindpirate/gogradle/task/go/GoVet.java
+++ b/src/main/java/com/github/blindpirate/gogradle/task/go/GoVet.java
@@ -45,7 +45,9 @@ public class GoVet extends Go {
 
     private void vet(List<String> fileNames) {
         if (!fileNames.isEmpty()) {
-            go(CollectionUtils.asStringList("tool", "vet", fileNames));
+            // Issue #287: `go tool vet` is deprecated in Go 1.12.
+            // @see https://go-review.googlesource.com/c/go/+/152161/3/doc/go1.12.html
+            go(CollectionUtils.asStringList("vet", fileNames));
         }
     }
 

--- a/src/test/groovy/com/github/blindpirate/gogradle/task/go/GoVetTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/task/go/GoVetTest.groovy
@@ -74,8 +74,8 @@ class GoVetTest extends TaskTest {
         List firstCall = captor.allValues[0]
         List secondCall = captor.allValues[1]
 
-        assert firstCall == ['tool', 'vet', toUnixString(new File(resource, 'main.go'))]
-        assert secondCall == ['tool', 'vet', toUnixString(new File(resource, 'sub'))]
+        assert firstCall == ['vet', toUnixString(new File(resource, 'main.go'))]
+        assert secondCall == ['vet', toUnixString(new File(resource, 'sub'))]
     }
 
     @Test
@@ -85,7 +85,7 @@ class GoVetTest extends TaskTest {
         task.executeTask()
         // then
         verify(buildManager).go(captor.capture(), anyMap(), any(Consumer), any(Consumer), eq(false))
-        assert captor.value == ['tool', 'vet', toUnixString(new File(resource, 'sub'))]
+        assert captor.value == ['vet', toUnixString(new File(resource, 'sub'))]
     }
 
     @Test


### PR DESCRIPTION
[F,287]
The command is deprecated since Go 1.12:
https://go-review.googlesource.com/c/go/+/152161/3/doc/go1.12.html

The command `go vet` is mentioned to work in older versions, too.

In my environment some com.github.blindpirate.gogradle.util.logging tests keep failing.
Those are NumberFormatExceptions which seem unhappy with the double values presented in German notation "5,730" instead of "5.730".
Hopefully this will not break CI.