### PR TITLE
Support macOS correctly again, Java 14, Gradle 6.4

### DIFF
--- a/.github/workflows/gogradle.yml
+++ b/.github/workflows/gogradle.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11]
-        os: [ubuntu-latest]
+        java: [8, 11, 14]
+        os: [ubuntu-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ gradle-app.setting
 
 # ANTLR tokens
 *.tokens
+
+dep/
+gogs/
+examples/
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ println System.getenv("PATH")
 apply from: 'config/scripts/coverage.gradle'
 
 group 'com.github.blindpirate'
-version '0.11.4'
+version '0.11.5'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
@@ -92,6 +92,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.16.1'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.0'
+    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
     testCompile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.5.3.201708160445-r'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.2.v20170220'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.2.v20170220'
@@ -111,7 +112,7 @@ dependencies {
 createIntegrationTest('integrationTest', 'integrationTest')
 
 List<String> gradleVersionsToBeTested = JavaVersion.current().isJava9Compatible()
-        ? ["4.8.1", "4.9", "4.10.3", "5.0"]
+        ? ["4.8.1", "4.9", "4.10.3", "5.0", "6.4.1"]
         : ["3.5.1", "4.0.1", "4.1", "4.2.1", "4.3.1", "4.4.1", "4.5.1", "4.6", "4.7", "4.8.1", "4.9", "4.10.3", "5.0"]
 
 gradleVersionsToBeTested.each {

--- a/buildSrc/src/main/groovy/com/github/blindpirate/gogradle/TestTop1000Task.groovy
+++ b/buildSrc/src/main/groovy/com/github/blindpirate/gogradle/TestTop1000Task.groovy
@@ -46,7 +46,7 @@ class TestTop1000Task extends DefaultTask {
         String buildDotGradle = """
 buildscript {
     dependencies {
-        classpath files('${getProject().getProjectDir().absolutePath}/build/libs/gogradle-0.11.4-all.jar')
+        classpath files('${getProject().getProjectDir().absolutePath}/build/libs/gogradle-0.11.5-all.jar')
     }
 }
 apply plugin: 'com.github.blindpirate.gogradle'

--- a/docs/build-go-with-gradle-en.md
+++ b/docs/build-go-with-gradle-en.md
@@ -65,7 +65,7 @@ Create a new file named `build.gradle` in your project root:
 
 ```
 plugins {
-    id 'com.github.blindpirate.gogradle' version '0.11.4' // Please use the latest version
+    id 'com.github.blindpirate.gogradle' version '0.11.5' // Please use the latest version
 }
 
 golang {

--- a/docs/build-go-with-gradle.md
+++ b/docs/build-go-with-gradle.md
@@ -70,7 +70,7 @@ Gogradle所需的一切仅仅是一个JVM。现在你需要安装JDK或者JRE 8+
 
 ```
 plugins {
-    id 'com.github.blindpirate.gogradle' version '0.11.4' // 请使用当前的最新版本
+    id 'com.github.blindpirate.gogradle' version '0.11.5' // 请使用当前的最新版本
 }
 
 golang {

--- a/docs/getting-started-cn.md
+++ b/docs/getting-started-cn.md
@@ -13,7 +13,7 @@ Gogradle是[Gradle](https://gradle.org/)的一个插件。Gradle是一个使用G
 
 ```groovy
 plugins {
-    id 'com.github.blindpirate.gogradle' version '0.11.4'
+    id 'com.github.blindpirate.gogradle' version '0.11.5'
 }
 
 golang {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ Before starting your work, you don't need to install Go and set `GOPATH`, of cou
 
 ```groovy
 plugins {
-    id 'com.github.blindpirate.gogradle' version '0.11.4'
+    id 'com.github.blindpirate.gogradle' version '0.11.5'
 }
 
 golang {

--- a/src/main/java/com/github/blindpirate/gogradle/GogradleGlobal.java
+++ b/src/main/java/com/github/blindpirate/gogradle/GogradleGlobal.java
@@ -24,7 +24,7 @@ import org.gradle.api.Project;
 public enum GogradleGlobal {
     INSTANCE;
 
-    public static final String GOGRADLE_VERSION = "0.11.4";
+    public static final String GOGRADLE_VERSION = "0.11.5";
     public static final String GOGRADLE_COMPATIBLE_VERSION = "0.10";
     public static final String DEFAULT_CHARSET = "UTF-8";
     public static final String GOGRADLE_BUILD_DIR_NAME = ".gogradle";

--- a/src/main/java/com/github/blindpirate/gogradle/core/GolangConfiguration.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/GolangConfiguration.java
@@ -25,11 +25,12 @@ import com.github.blindpirate.gogradle.core.dependency.GolangDependencySet;
 import com.github.blindpirate.gogradle.core.dependency.parse.NotationParser;
 import com.github.blindpirate.gogradle.core.pack.PackagePathResolver;
 import groovy.lang.Closure;
-import org.apache.commons.lang3.tuple.Pair;
+import com.google.common.collect.Maps;
 import org.gradle.util.ConfigureUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class GolangConfiguration {
     public static final String BUILD = "build";
@@ -38,7 +39,7 @@ public class GolangConfiguration {
     private final String name;
     private final GolangDependencySet dependencies = new GolangDependencySet();
     private final DependencyRegistry dependencyRegistry;
-    private final List<Pair<Object, Closure>> firstLevelDependencies = new ArrayList<>();
+    private final List<Map.Entry<Object, Closure>> firstLevelDependencies = new ArrayList<>();
     private final NotationParser<Object> notationParser;
 
     private boolean resolved;
@@ -56,7 +57,7 @@ public class GolangConfiguration {
     public GolangDependencySet getDependencies() {
         if (!resolved) {
             resolved = true;
-            firstLevelDependencies.forEach(pair -> dependencies.add(create(pair.getLeft(), pair.getRight())));
+            firstLevelDependencies.forEach(pair -> dependencies.add(create(pair.getKey(), pair.getValue())));
         }
         return dependencies;
     }
@@ -66,7 +67,7 @@ public class GolangConfiguration {
     }
 
     public void addFirstLevelDependency(Object notation, Closure closure) {
-        firstLevelDependencies.add(Pair.of(notation, closure));
+        firstLevelDependencies.add(Maps.immutableEntry(notation, closure));
     }
 
     public GolangDependency create(Object dependencyNotation, Closure configureClosure) {

--- a/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/external/gopm/GopmfileParser.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/dependency/produce/external/gopm/GopmfileParser.java
@@ -19,7 +19,7 @@ package com.github.blindpirate.gogradle.core.dependency.produce.external.gopm;
 
 import com.github.blindpirate.gogradle.util.IOUtils;
 import com.github.blindpirate.gogradle.util.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
+import com.google.common.collect.Maps;
 
 import java.io.File;
 import java.util.Collections;
@@ -101,17 +101,17 @@ public class GopmfileParser {
                 .collect(Collectors.toList());
     }
 
-    private Pair<String, String> parseLine(String line) {
+    private Map.Entry<String, String> parseLine(String line) {
         String[] nameAndValue = splitAndTrim(line, "=");
         String name = nameAndValue[0];
         String value = nameAndValue.length > 1 ? nameAndValue[1] : "";
-        return Pair.of(name, value);
+        return Maps.immutableEntry(name, value);
 
     }
 
-    private Map<String, Object> toNotation(Pair<String, String> nameAndValue) {
-        String name = nameAndValue.getLeft();
-        String value = nameAndValue.getRight();
+    private Map<String, Object> toNotation(Map.Entry<String, String> nameAndValue) {
+        String name = nameAndValue.getKey();
+        String value = nameAndValue.getValue();
 
         Map<String, Object> ret = new HashMap<>();
         ret.put(NAME_KEY, name);

--- a/src/main/java/com/github/blindpirate/gogradle/core/pack/VcsPackagePathResolver.java
+++ b/src/main/java/com/github/blindpirate/gogradle/core/pack/VcsPackagePathResolver.java
@@ -5,8 +5,9 @@ import com.github.blindpirate.gogradle.core.GolangRepository;
 import com.github.blindpirate.gogradle.core.VcsGolangPackage;
 import com.github.blindpirate.gogradle.util.StringUtils;
 import com.github.blindpirate.gogradle.vcs.VcsType;
-import org.apache.commons.lang3.tuple.Pair;
+import com.google.common.collect.Maps;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -16,13 +17,13 @@ import static java.util.stream.Collectors.toList;
 public class VcsPackagePathResolver extends AbstractPackagePathResolver {
     @Override
     protected GolangPackage doProduce(String packagePath) {
-        Pair<String, VcsType> rootPathAndVcsType = StringUtils.eachSubPath(packagePath)
-                .map(subPath -> Pair.of(subPath, findEndingVcs(subPath)))
-                .filter((Pair<String, VcsType> pair) -> pair.getRight() != null)
+        Map.Entry<String, VcsType> rootPathAndVcsType = StringUtils.eachSubPath(packagePath)
+                .map(subPath -> Maps.immutableEntry(subPath, findEndingVcs(subPath)))
+                .filter((Map.Entry<String, VcsType> pair) -> pair.getValue() != null)
                 .findFirst().get();
 
-        String rootPath = rootPathAndVcsType.getLeft();
-        VcsType vcsType = rootPathAndVcsType.getRight();
+        String rootPath = rootPathAndVcsType.getKey();
+        VcsType vcsType = rootPathAndVcsType.getValue();
         GolangRepository repository = newOriginalRepository(vcsType,
                 vcsType.getSchemes().stream().map(scheme -> scheme.buildUrl(rootPath)).collect(toList()));
 

--- a/src/main/java/com/github/blindpirate/gogradle/crossplatform/Os.java
+++ b/src/main/java/com/github/blindpirate/gogradle/crossplatform/Os.java
@@ -22,14 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.commons.lang3.SystemUtils.IS_OS_AIX;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_FREE_BSD;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_LINUX;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC_OSX;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_NET_BSD;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_SOLARIS;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_ZOS;
+import static org.apache.commons.lang3.SystemUtils.*;
 
 // https://github.com/golang/go/blob/master/src/go/build/syslist.go
 public enum Os {
@@ -95,7 +88,7 @@ public enum Os {
             .put(FREEBSD, IS_OS_FREE_BSD)
             .put(NETBSD, IS_OS_NET_BSD)
             .put(SOLARIS, IS_OS_SOLARIS)
-            .put(ZOS, IS_OS_ZOS)
+            .put(ZOS, false)
             .build();
 
     private static Os detectOs() {

--- a/src/main/java/com/github/blindpirate/gogradle/task/go/GoBuild.java
+++ b/src/main/java/com/github/blindpirate/gogradle/task/go/GoBuild.java
@@ -26,7 +26,7 @@ import com.github.blindpirate.gogradle.crossplatform.Os;
 import com.github.blindpirate.gogradle.util.Assert;
 import com.github.blindpirate.gogradle.util.MapUtils;
 import com.github.blindpirate.gogradle.util.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
+import com.google.common.collect.Maps;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -62,7 +62,7 @@ public class GoBuild extends Go {
 
     private String outputLocation;
 
-    private List<Pair<Os, Arch>> targetPlatforms = singletonList(Pair.of(Os.getHostOs(), Arch.getHostArch()));
+    private List<Map.Entry<Os, Arch>> targetPlatforms = singletonList(Maps.immutableEntry(Os.getHostOs(), Arch.getHostArch()));
 
     public GoBuild() {
         setDescription("Run build and generate output.");
@@ -74,9 +74,9 @@ public class GoBuild extends Go {
 
     @Override
     public void afterEvaluate() {
-        targetPlatforms.forEach(osArchPair -> {
-            Os os = osArchPair.getLeft();
-            Arch arch = osArchPair.getRight();
+        targetPlatforms.forEach(osArchMap -> {
+            Os os = osArchMap.getKey();
+            Arch arch = osArchMap.getValue();
 
             Go task = createSingleGoTask(os, arch);
             task.dependsOn(INSTALL_DEPENDENCIES_TASK_NAME, RESOLVE_BUILD_DEPENDENCIES_TASK_NAME);
@@ -181,16 +181,16 @@ public class GoBuild extends Go {
         targetPlatforms = new ArrayList<>(new LinkedHashSet<>(targetPlatforms));
     }
 
-    private List<Pair<Os, Arch>> extractPlatforms(String targetPlatform) {
+    private List<Map.Entry<Os, Arch>> extractPlatforms(String targetPlatform) {
         String[] platforms = splitAndTrim(targetPlatform, ",");
         return Stream.of(platforms).map(this::extractOne).collect(toList());
     }
 
-    private Pair<Os, Arch> extractOne(String osAndArch) {
+    private Map.Entry<Os, Arch> extractOne(String osAndArch) {
         String[] osArch = splitAndTrim(osAndArch, "\\-");
         Os os = Os.of(osArch[0]);
         Arch arch = Arch.of(osArch[1]);
-        return Pair.of(os, arch);
+        return Maps.immutableEntry(os, arch);
     }
 
     private Map<String, String> getEffectiveEnvironment(Os os, Arch arch) {

--- a/src/main/java/com/github/blindpirate/gogradle/task/go/test/PlainGoTestResultExtractor.java
+++ b/src/main/java/com/github/blindpirate/gogradle/task/go/test/PlainGoTestResultExtractor.java
@@ -19,7 +19,7 @@ package com.github.blindpirate.gogradle.task.go.test;
 
 import com.github.blindpirate.gogradle.task.go.PackageTestResult;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.tuple.Pair;
+import com.google.common.collect.Maps;
 import org.gradle.api.tasks.testing.TestResult;
 
 import java.util.ArrayList;
@@ -46,15 +46,15 @@ public class PlainGoTestResultExtractor extends AbstractGoTestResultExtractor {
 
     protected List<GoTestMethodResult> extractMethodResults(PackageTestResult packageTestResult) {
         List<String> stdout = removeTailMessages(packageTestResult.getStdout());
-        List<Pair<Integer, String>> testStartIndicesAndNames = extractStartIndiceAndTestMethodNames(stdout);
+        List<Map.Entry<Integer, String>> testStartIndicesAndNames = extractStartIndiceAndTestMethodNames(stdout);
 
         List<GoTestMethodResult> ret = new ArrayList<>();
         for (int i = 0; i < testStartIndicesAndNames.size(); ++i) {
-            int currentIndex = testStartIndicesAndNames.get(i).getLeft();
-            String currentMethodName = testStartIndicesAndNames.get(i).getRight();
+            int currentIndex = testStartIndicesAndNames.get(i).getKey();
+            String currentMethodName = testStartIndicesAndNames.get(i).getValue();
             int nextIndex = i == testStartIndicesAndNames.size() - 1
                     ? stdout.size()
-                    : testStartIndicesAndNames.get(i + 1).getLeft();
+                    : testStartIndicesAndNames.get(i + 1).getKey();
             ret.add(extractOneTestMethod(currentMethodName, stdout.subList(currentIndex, nextIndex)));
         }
 
@@ -89,13 +89,13 @@ public class PlainGoTestResultExtractor extends AbstractGoTestResultExtractor {
         return stdout;
     }
 
-    private List<Pair<Integer, String>> extractStartIndiceAndTestMethodNames(List<String> stdout) {
-        List<Pair<Integer, String>> ret = new ArrayList<>();
+    private List<Map.Entry<Integer, String>> extractStartIndiceAndTestMethodNames(List<String> stdout) {
+        List<Map.Entry<Integer, String>> ret = new ArrayList<>();
 
         for (int i = 0; i < stdout.size(); ++i) {
             Optional<String> testName = getRootTestNameFromLine(stdout.get(i));
             if (testName.isPresent()) {
-                ret.add(Pair.of(i, testName.get()));
+                ret.add(Maps.immutableEntry(i, testName.get()));
             }
         }
         return ret;

--- a/src/main/java/com/github/blindpirate/gogradle/util/MapUtils.java
+++ b/src/main/java/com/github/blindpirate/gogradle/util/MapUtils.java
@@ -17,7 +17,7 @@
 
 package com.github.blindpirate.gogradle.util;
 
-import org.apache.commons.lang3.tuple.Pair;
+import com.google.common.collect.Maps;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,61 +44,61 @@ public class MapUtils {
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMap(K k1, V v1, K k2, V v2) {
-        return asMap(new Pair[]{Pair.of(k1, v1), Pair.of(k2, v2)});
+        return asMap(new Map.Entry[]{Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2)});
     }
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMap(K k1, V v1, K k2, V v2, K k3, V v3) {
-        return asMap(Pair.of(k1, v1), Pair.of(k2, v2), Pair.of(k3, v3));
+        return asMap(Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2), Maps.immutableEntry(k3, v3));
     }
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMap(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
-        return asMap(new Pair[]{Pair.of(k1, v1), Pair.of(k2, v2), Pair.of(k3, v3), Pair.of(k4, v4)});
+        return asMap(new Map.Entry[]{Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2), Maps.immutableEntry(k3, v3), Maps.immutableEntry(k4, v4)});
     }
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMap(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
-        return asMap(Pair.of(k1, v1), Pair.of(k2, v2), Pair.of(k3, v3), Pair.of(k4, v4), Pair.of(k5, v5));
+        return asMap(Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2), Maps.immutableEntry(k3, v3), Maps.immutableEntry(k4, v4), Maps.immutableEntry(k5, v5));
     }
 
-    private static <K, V> Map<K, V> asMap(Pair<K, V>... entries) {
+    private static <K, V> Map<K, V> asMap(Map.Entry<K, V>... entries) {
         Map<K, V> ret = new HashMap<>();
-        for (Pair<K, V> entry : entries) {
-            ret.put(entry.getLeft(), entry.getRight());
+        for (Map.Entry<K, V> entry : entries) {
+            ret.put(entry.getKey(), entry.getValue());
         }
         return ret;
     }
 
     public static <K, V> Map<K, V> asMapWithoutNull(K k, V v) {
-        return asMapWithoutNull(Pair.of(k, v));
+        return asMapWithoutNull(Maps.immutableEntry(k, v));
     }
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMapWithoutNull(K k1, V v1, K k2, V v2, K k3, V v3) {
-        return asMapWithoutNull(Pair.of(k1, v1), Pair.of(k2, v2), Pair.of(k3, v3));
+        return asMapWithoutNull(Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2), Maps.immutableEntry(k3, v3));
     }
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMapWithoutNull(K k1, V v1, K k2, V v2) {
-        return asMapWithoutNull(new Pair[]{Pair.of(k1, v1), Pair.of(k2, v2)});
+        return asMapWithoutNull(new Map.Entry[]{Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2)});
     }
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMapWithoutNull(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
-        return asMapWithoutNull(new Pair[]{Pair.of(k1, v1), Pair.of(k2, v2), Pair.of(k3, v3), Pair.of(k4, v4)});
+        return asMapWithoutNull(new Map.Entry[]{Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2), Maps.immutableEntry(k3, v3), Maps.immutableEntry(k4, v4)});
     }
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMapWithoutNull(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
-        return asMapWithoutNull(Pair.of(k1, v1), Pair.of(k2, v2), Pair.of(k3, v3), Pair.of(k4, v4), Pair.of(k5, v5));
+        return asMapWithoutNull(Maps.immutableEntry(k1, v1), Maps.immutableEntry(k2, v2), Maps.immutableEntry(k3, v3), Maps.immutableEntry(k4, v4), Maps.immutableEntry(k5, v5));
     }
 
-    private static <K, V> Map<K, V> asMapWithoutNull(Pair<K, V>... entries) {
+    private static <K, V> Map<K, V> asMapWithoutNull(Map.Entry<K, V>... entries) {
         Map<K, V> ret = new HashMap<>();
-        for (Pair<K, V> entry : entries) {
-            if (entry.getLeft() != null && entry.getRight() != null) {
-                ret.put(entry.getLeft(), entry.getRight());
+        for (Map.Entry<K, V> entry : entries) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                ret.put(entry.getKey(), entry.getValue());
             }
         }
         return ret;
@@ -106,6 +106,6 @@ public class MapUtils {
 
     @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> asMap(K k, V v) {
-        return asMapWithoutNull(Pair.of(k, v));
+        return asMapWithoutNull(Maps.immutableEntry(k, v));
     }
 }

--- a/src/test/groovy/com/github/blindpirate/gogradle/core/GolangConfigurationTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/core/GolangConfigurationTest.groovy
@@ -51,8 +51,8 @@ class GolangConfigurationTest {
         // then
         List firstLevelDependencies = configuration.firstLevelDependencies
         assert firstLevelDependencies.size() == 1
-        assert firstLevelDependencies[0].left == [:]
-        assert firstLevelDependencies[0].right() == 1
+        assert firstLevelDependencies[0].key == [:]
+        assert firstLevelDependencies[0].value() == 1
         assert configuration.hasFirstLevelDependencies()
     }
 

--- a/src/test/groovy/com/github/blindpirate/gogradle/task/GoBuildTest.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/task/GoBuildTest.groovy
@@ -176,25 +176,27 @@ class GoBuildTest extends TaskTest {
 
     @Test
     void 'setting target platform should succeed'() {
-        task.targetPlatform = 'windows-amd64, linux-amd64, linux-386'
+        task.targetPlatform = 'windows-amd64, linux-amd64, linux-386, darwin-amd64'
         assertTargetPlatforms()
     }
 
     @Test
     void 'duplicates should be removed'() {
-        task.targetPlatform = 'windows-amd64, linux-amd64, linux-386,windows-amd64'
+        task.targetPlatform = 'windows-amd64, linux-amd64, linux-386, windows-amd64, darwin-amd64'
         assertTargetPlatforms()
 
         task.targetPlatform = ['windows-amd64', 'linux-amd64', 'linux-386', 'windows-amd64']
     }
 
     private void assertTargetPlatforms() {
-        assert task.targetPlatforms[0].left == Os.WINDOWS
-        assert task.targetPlatforms[0].right == Arch.AMD64
-        assert task.targetPlatforms[1].left == Os.LINUX
-        assert task.targetPlatforms[1].right == Arch.AMD64
-        assert task.targetPlatforms[2].left == Os.LINUX
-        assert task.targetPlatforms[2].right == Arch.I386
+        assert task.targetPlatforms[0].key == Os.WINDOWS
+        assert task.targetPlatforms[0].value == Arch.AMD64
+        assert task.targetPlatforms[1].key == Os.LINUX
+        assert task.targetPlatforms[1].value == Arch.AMD64
+        assert task.targetPlatforms[2].key == Os.LINUX
+        assert task.targetPlatforms[2].value == Arch.I386
+        assert task.targetPlatforms[3].key == Os.DARWIN
+        assert task.targetPlatforms[3].value == Arch.AMD64
     }
 
     @Test

--- a/src/test/groovy/com/github/blindpirate/gogradle/util/ReflectionUtils.groovy
+++ b/src/test/groovy/com/github/blindpirate/gogradle/util/ReflectionUtils.groovy
@@ -18,6 +18,7 @@
 package com.github.blindpirate.gogradle.util
 
 import org.joor.Reflect
+import org.powermock.reflect.Whitebox
 
 import java.lang.reflect.Field
 import java.lang.reflect.InvocationTargetException
@@ -44,13 +45,7 @@ class ReflectionUtils {
     // WARNING: do not set a static final field after getting it first
     // it will cause issues
     static void setStaticFinalField(Class targetClass, String fieldName, Object value) {
-        Field field = org.gradle.internal.impldep.org.codehaus.plexus.util.ReflectionUtils
-                .getFieldByNameIncludingSuperclasses(fieldName, targetClass)
-        field.setAccessible(true)
-        Field modifiersField = Field.class.getDeclaredField('modifiers')
-        modifiersField.setAccessible(true)
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL)
-        field.set(null, value)
+        Whitebox.setInternalState(targetClass, fieldName, value);
     }
 
     static Object getStaticField(Class target, String fieldName) {


### PR DESCRIPTION
Fixes #318 

 - Upgrades commons-lang3 to 3.11
 - Replaces invalid use of Pair with Maps.immutableEntry from Guava
 - Reintroduce macOS GitHub Actions test
 - Remove ZOS from Os because it throws errors (Apache Commons problem)

For users finding this issue and wanting to use `gogradle` on macOS right now, use the following buildscript:

```
buildscript {
    repositories {
        maven { url 'https://jitpack.io' }
    }
    dependencies {
        classpath 'com.github.doctorpangloss:gogradle:adae13ed1d'
    }
}

apply plugin: 'com.github.blindpirate.gogradle'

golang {
    packagePath = 'github.com/...'
}
```